### PR TITLE
Define HAVE_UNISTD_H on Mac Catalyst

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .headerSearchPath("."),
         .define("HAVE_ATTRIBUTE_ALIGNED", to: "1"),
         .define("WITH_GZFILEOP", to: "1"),
-        .define("HAVE_UNISTD_H", to: "1", .when(platforms: [.macOS, .iOS, .visionOS, .tvOS, .watchOS, .linux, .android])),
+        .define("HAVE_UNISTD_H", to: "1", .when(platforms: [.macOS, .iOS, .visionOS, .tvOS, .watchOS, .linux, .android, .macCatalyst])),
         .define("Z_HAVE_STDARG_H", to: "1"),
       ],
       cxxSettings: [


### PR DESCRIPTION
This was causing compilation errors when building for Mac Catalyst that didn't happen when building for macOS or iOS.